### PR TITLE
small fix when receiving messages from hc

### DIFF
--- a/wishful_controller/hierarchical_control_module.py
+++ b/wishful_controller/hierarchical_control_module.py
@@ -26,7 +26,7 @@ class LocalControlProgramDescriptor(object):
     def recv(self, block=True, timeout=None):
         try:
             self.log.debug("Waiting for msg in blocking call")
-            msg = self.queue.get(block=True, timeout=timeout)
+            msg = self.queue.get(block=block, timeout=timeout)
             return msg
         except gevent.timeout.Timeout as e:
             return None


### PR DESCRIPTION
Can someone verify that allowing non-blocking get from queue in hierarchical controller is allowed.
I need to do this because otherwise I get an assertion error during the timout period of the Queue.get() operation. This occurs when there is no msg in the Queue and a message arrives before the timeout.

2016-10-06 20:04:57,863 - LocalControlProgramDescriptor_1.recv() - DEBUG - Waiting for msg in blocking call
2016-10-06 20:04:58,569 - wishful_controller.controller.Controller.process_msgs() - DEBUG - Controller received message: hierarchical_control from agent
Traceback (most recent call last):
  File "/groups/portable-ilabt-iminds-be/wishful/repos/wishful/dev/lib/python3.4/site-packages/gevent/hub.py", line 844, in switch
    assert getcurrent() is self.hub, "Can only use Waiter.switch method from the Hub greenlet"
AssertionError: Can only use Waiter.switch method from the Hub greenlet
